### PR TITLE
Add sample dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.ssh
+.cache
+*.md
+docker-compose.yml
+


### PR DESCRIPTION
Shouldn't matter much here, as the image & repo are quite small (and neat! Well done!).

Before:

```
Sending build context to Docker daemon  109.1kB
```

After:

```
Sending build context to Docker daemon  30.72kB
```

And I made a note to always have `.ssh` in my `.dockerignore` as I once almost uploaded an image with SSH server keys :disappointed_relieved: 